### PR TITLE
Gracefully handle not being called in a CGI environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ cgi::cgi_try_main! { |request: cgi::Request| -> Result<cgi::Response, String> {
 It will parse and extract the CGI environmental variables, and the HTTP request body to create
 `Request<u8>`, call your function to create a response, and convert your `Response` into the
 correct format and print to stdout. If this program is not called as CGI (e.g. missing
-required environmental variables), it will panic.
+required environmental variables), it will gracefully fall back to using reasonable values
+(although the values themselves may be subject to change).
 
 It is also possible to call the `rust_cgi::handle` function directly inside your `main` function:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -404,6 +404,17 @@ mod tests {
     }
 
     #[test]
+    fn test_empty() {
+        let env_vars = env(vec![]);
+        let stdin = Vec::new();
+        let req = parse_request(env_vars, stdin);
+        assert_eq!(req.method(), &http::method::Method::GET);
+        // We don't want to assert any particular values for
+        // anything else in the request, but as long as the above
+        // didn't panic we're good.
+    }
+
+    #[test]
     fn test_parse_request() {
         let env_vars = env(vec![
             ("REQUEST_METHOD", "GET"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,11 +276,12 @@ fn parse_request(env_vars: HashMap<String, String>, stdin: Vec<u8>) -> Request {
     let mut req = http::Request::builder();
 
     req = req.method(env_vars.get("REQUEST_METHOD").map_or("GET", String::as_str));
-    let uri = if env_vars.get("QUERY_STRING").unwrap_or(&"".to_owned()) != "" {
-        format!("{}?{}", env_vars["SCRIPT_NAME"], env_vars["QUERY_STRING"])
-    } else {
-        env_vars["SCRIPT_NAME"].to_owned()
-    };
+    let mut uri = env_vars["SCRIPT_NAME"].clone();
+
+    if env_vars.contains_key("QUERY_STRING") {
+        uri.push_str("?");
+        uri.push_str(&env_vars["QUERY_STRING"]);
+    }
     req = req.uri(uri.as_str());
 
     if let Some(v) = env_vars.get("SERVER_PROTOCOL") {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,7 +275,7 @@ where
 fn parse_request(env_vars: HashMap<String, String>, stdin: Vec<u8>) -> Request {
     let mut req = http::Request::builder();
 
-    req = req.method(env_vars["REQUEST_METHOD"].as_str());
+    req = req.method(env_vars.get("REQUEST_METHOD").map_or("GET", String::as_str));
     let uri = if env_vars.get("QUERY_STRING").unwrap_or(&"".to_owned()) != "" {
         format!("{}?{}", env_vars["SCRIPT_NAME"], env_vars["QUERY_STRING"])
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,11 +272,23 @@ where
     response.body(body).unwrap()
 }
 
+fn exe_url() -> String {
+    // maybe use http::uri::Uri instead.
+    // note: the http crate that this outputs to only accepts http/https URLs,
+    // so we're going to leave off the scheme entirely
+    match std::env::current_exe() {
+        Ok(p) => p.to_string_lossy().into_owned(),
+        Err(_) => String::new(),
+    }
+}
+
 fn parse_request(env_vars: HashMap<String, String>, stdin: Vec<u8>) -> Request {
     let mut req = http::Request::builder();
 
     req = req.method(env_vars.get("REQUEST_METHOD").map_or("GET", String::as_str));
-    let mut uri = env_vars["SCRIPT_NAME"].clone();
+    let mut uri = env_vars
+        .get("SCRIPT_NAME")
+        .map_or_else(exe_url, String::clone);
 
     if env_vars.contains_key("QUERY_STRING") {
         uri.push_str("?");


### PR DESCRIPTION
This allows rust CGI scripts to be more easily iterated on since you can just execute them directly.