### PR TITLE
Fix a name and update the suggested version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Installation & Usage
 
 ```toml
 [dependencies]
-rust-cgi = "0.6"
+rust-cgi = "0.7.1"
 ```
 
 Use the `cgi_main!` macro, with a function that takes a `rust_cgi::Request` and returns a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! ```cargo,ignore
 //! [dependencies]
-//! rust_cgi = "0.3"
+//! rust-cgi = "0.7.1"
 //! ```
 //!
 //!


### PR DESCRIPTION
The crate is called "rust-cgi" not "rust_cgi".